### PR TITLE
Open the form on new examinations

### DIFF
--- a/libreosteoweb/static/js/app/examination.js
+++ b/libreosteoweb/static/js/app/examination.js
@@ -123,6 +123,10 @@ examination.directive('examination', ['ExaminationServ', function(ExaminationSer
             });
 
             $scope.updateDeleteTrigger = function() {
+                if ($scope.newExamination) {
+                    $scope.editableForm.$show();
+                }
+
                 if($scope.model == null)
                 {
                     $scope.triggerEditForm.delete = false;


### PR DESCRIPTION
Avoid clicking on "edit", as new empty examinations are likely to be written
rather than read.