### PR TITLE
Remove deprecated TEMPLATE_DEBUG setting

### DIFF
--- a/Libreosteo/settings/demonstration.py
+++ b/Libreosteo/settings/demonstration.py
@@ -4,7 +4,7 @@ import os
 DEMONSTRATION = True
 
 DEBUG = False
-TEMPLATE_DEBUG = False
+TEMPLATES[0]['OPTIONS']['debug'] = False
 
 DATABASES['default']['NAME'] = os.path.join(DATA_FOLDER, '../db.sqlite3')
 REST_FRAMEWORK['DEFAULT_RENDERER_CLASSES'] = ('rest_framework.renderers.JSONRenderer',)

--- a/Libreosteo/settings/dev.py
+++ b/Libreosteo/settings/dev.py
@@ -16,7 +16,7 @@
 from .base import *
 
 DEBUG=True
-TEMPLATE_DEBUG = True
+TEMPLATES[0]['OPTIONS']['debug'] = True
 COMPRESS_ENABLED = False
 
 try :

--- a/Libreosteo/settings/standalone.py
+++ b/Libreosteo/settings/standalone.py
@@ -16,7 +16,7 @@
 from .base import *
 
 DEBUG = True
-TEMPLATE_DEBUG = True
+TEMPLATES[0]['OPTIONS']['debug'] = True
 COMPRESS_ENABLED = True
 
 try :


### PR DESCRIPTION
Was causing a warning on console :

    ?: (1_8.W001) The standalone TEMPLATE_* settings were deprecated in Django 1.8 and the TEMPLATES dictionary takes precedence. You must put the values of the following settings into your default TEMPLATES dict: TEMPLATE_DEBUG.