### PR TITLE
Log all HTTP requests while using development server

### DIFF
--- a/Libreosteo/settings/base.py
+++ b/Libreosteo/settings/base.py
@@ -250,6 +250,11 @@ LOGGING = {
             'level': 'ERROR',
             'propagate': False,
         },
+        'django.server': {
+            'handlers': ['console'],
+            'level': 'INFO',
+            'propagate': False,
+        },
         'libreosteoweb': {
             'handlers': ['console'],
             'level': 'INFO',


### PR DESCRIPTION
Unless that was deliberate to hide them. 

Not that this param applies to the development server only (`django.server` has been introduced in Django 1.10).