### PR TITLE
Replace render_to_response() calls with render()

### DIFF
--- a/libreosteoweb/api/displays.py
+++ b/libreosteoweb/api/displays.py
@@ -13,7 +13,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Libreosteo.  If not, see <http://www.gnu.org/licenses/>.
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.forms.models import ModelForm
 from libreosteoweb import models 
 from django.contrib.auth.models import User
@@ -71,78 +71,78 @@ class OfficeSettingsDisplay(GenericDisplay):
         fields = [ f.name for f in model._meta.fields if f.editable ]
 
 def display_index(request):
-    return render_to_response('index.html', {'version' : libreosteoweb.__version__ , 'request' : request })
+    return render(request, 'index.html', {'version' : libreosteoweb.__version__ , 'request' : request })
 
 def display_patient(request):
     display = PatientDisplay()
     displayExamination = ExaminationDisplay()
-    return render_to_response('partials/patient-detail.html', {'patient' : display.display_fields(),
+    return render(request, 'partials/patient-detail.html', {'patient' : display.display_fields(),
                                                                'examination' : displayExamination.display_fields()})
 
 def display_newpatient(request):
     display = PatientDisplay()
-    return render_to_response('partials/add-patient.html', {'patient' : display.display_fields()})
+    return render(request, 'partials/add-patient.html', {'patient' : display.display_fields()})
 
 def display_doctor(request):
     display = RegularDoctorDisplay()
-    return render_to_response('partials/doctor-modal-add.html', {'doctor':display.display_fields()})
+    return render(request, 'partials/doctor-modal-add.html', {'doctor':display.display_fields()})
 
 def display_examination_timeline(request):
     display = ExaminationDisplay()
-    return render_to_response('partials/timeline.html', {'examination' : display.display_fields()})
+    return render(request, 'partials/timeline.html', {'examination' : display.display_fields()})
 
 def display_examination(request):
     displayExamination = ExaminationDisplay()
-    return render_to_response('partials/examination.html', {'examination' : displayExamination.display_fields()})
+    return render(request, 'partials/examination.html', {'examination' : displayExamination.display_fields()})
 
 def display_search_result(request):
-    return render_to_response('partials/search-result.html', {})
+    return render(request, 'partials/search-result.html', {})
 
 def display_userprofile(request):
     displayUser = UserDisplay()
     displayTherapeutSettings = TherapeutSettingsDisplay()
-    return render_to_response('partials/user-profile.html', {'user' : displayUser.display_fields(), 
+    return render(request, 'partials/user-profile.html', {'user' : displayUser.display_fields(), 
         'therapeutsettings': displayTherapeutSettings.display_fields(),
         'DEMONSTRATION' : settings.DEMONSTRATION })
 
 def display_dashboard(request):
-    return render_to_response('partials/dashboard.html', {})
+    return render(request, 'partials/dashboard.html', {})
 
 def display_officeevent(request):
-    return render_to_response('partials/officeevent.html', {})
+    return render(request, 'partials/officeevent.html', {})
 
 def display_invoicing(request):
-    return render_to_response('partials/invoice-modal.html', {})
+    return render(request, 'partials/invoice-modal.html', {})
 
 def display_officesettings(request):
     displayOfficeSettings = OfficeSettingsDisplay()
-    return render_to_response('partials/office-settings.html', {'officesettings' : displayOfficeSettings.display_fields, 'user':request.user})
+    return render(request, 'partials/office-settings.html', {'officesettings' : displayOfficeSettings.display_fields, 'user':request.user})
 
 def display_adduser(request):
-    return render_to_response('partials/add-user-modal.html', {})
+    return render(request, 'partials/add-user-modal.html', {})
 
 def display_setpassword(request):
-    return render_to_response('partials/set-password-user-modal.html', {})
+    return render(request, 'partials/set-password-user-modal.html', {})
 
 def display_import_files(request):
-    return render_to_response('partials/import-file.html', {'request' : request})
+    return render(request, 'partials/import-file.html', {'request' : request})
 
 def display_rebuild_index(request):
-    return render_to_response('partials/rebuild-index.html', {'request' : request})
+    return render(request, 'partials/rebuild-index.html', {'request' : request})
 
 def display_file_manager(request):
-    return render_to_response('partials/filemanager.html', {'request' : request})
+    return render(request, 'partials/filemanager.html', {'request' : request})
 
 def display_confirmation(request):
-    return render_to_response('partials/confirmation.html')
+    return render(request, 'partials/confirmation.html')
 
 @never_cache
 @maintenance_available()
 def display_restore(request):
-    return render_to_response('partials/restore.html', {'request' : request})
+    return render(request, 'partials/restore.html', {'request' : request})
 
 
 @never_cache
 @maintenance_available()
 def display_register(request):
-    return render_to_response('partials/register.html', {'csrf_token' : request.COOKIES['csrftoken']})
+    return render(request, 'partials/register.html', {'csrf_token' : request.COOKIES['csrftoken']})

--- a/libreosteoweb/api/views.py
+++ b/libreosteoweb/api/views.py
@@ -73,7 +73,7 @@ class CreateAdminAccountView(TemplateView):
         self.redirect_to = request.POST.get(REDIRECT_FIELD_NAME,
             request.GET.get(REDIRECT_FIELD_NAME, ''))
         self.form = UserCreationForm()
-        return super(TemplateView, self).render_to_response(self.get_context_data())
+        return super(TemplateView, self).render(request, self.get_context_data())
 
 
     def post(self, request, *args, **kwargs):
@@ -89,7 +89,7 @@ class CreateAdminAccountView(TemplateView):
             return HttpResponseRedirect(redirect_to)
         else :
             self.form = form
-        return super(TemplateView, self).render_to_response(self.get_context_data())
+        return super(TemplateView, self).render(request, self.get_context_data())
 
     def get_context_data(self, **kwargs):
         context = super(CreateAdminAccountView, self).get_context_data(**kwargs)
@@ -111,12 +111,12 @@ class InstallView(TemplateView):
             raise HttpResponseForbidden
         self.redirect_field_name = request.POST.get(REDIRECT_FIELD_NAME,
             request.GET.get(REDIRECT_FIELD_NAME, ''))
-        return super(TemplateView, self).render_to_response(self.get_context_data())
+        return super(TemplateView, self).render(request, self.get_context_data())
 
     def post(self, request, *args, **kwargs):
         if len(User.objects.filter(is_staff__exact=True)) > 0 :
             raise HttpResponseForbidden
-        return super(TemplateView, self).render_to_response(self.get_context_data())
+        return super(TemplateView, self).render(request, self.get_context_data())
 
     def get_context_data(self, **kwargs):
         context = super(TemplateView, self).get_context_data(**kwargs)


### PR DESCRIPTION
As render_to_response() is pending deprecation (and long to write ;-), see

https://docs.djangoproject.com/en/1.11/topics/http/shortcuts/#render-to-response