### PR TITLE
Raise the data volume used to guess CSV dialect

### DIFF
--- a/libreosteoweb/api/file_integrator.py
+++ b/libreosteoweb/api/file_integrator.py
@@ -214,7 +214,7 @@ class FileContentAdapter(dict):
             return None
         self.file.open(mode='rb')
         logger.info("* Try to guess the dialect on csv")
-        dialect = csv.Sniffer().sniff(self.file.read(4096))
+        dialect = csv.Sniffer().sniff(self.file.read(1024 * 1024 * 10))
         self.file.seek(0)
         reader = csv.reader(self.file, dialect)
         return reader


### PR DESCRIPTION
In some (actual) cases, examination data can be so long that 4ko is not enough to
contain a single line.

After some tests, 10Mio seemed a good compromise to me between performance (<1s
 runtime, and 10Mio RAM is nothing on nowadays computers) and robustness.

FYI, I had no success on my file reading less than 1Mio data (dialect was wrongly detected)