### PR TITLE
Fix dev dependency, yarn issue with momentjs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
   - wget --no-verbose -O /tmp/firefox-latest.tar.bz2 $FIREFOX_SOURCE_URL
   - tar -xjf /tmp/firefox-latest.tar.bz2
   - export PATH=$PWD/firefox:$PATH
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.22.1
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.22.2
   - export PATH="$HOME/.yarn/bin:$PATH"
 install:
   - pip install -r requirements/requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
   - wget --no-verbose -O /tmp/firefox-latest.tar.bz2 $FIREFOX_SOURCE_URL
   - tar -xjf /tmp/firefox-latest.tar.bz2
   - export PATH=$PWD/firefox:$PATH
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.21.0
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.21.1
   - export PATH="$HOME/.yarn/bin:$PATH"
 install:
   - pip install -r requirements/requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
   - wget --no-verbose -O /tmp/firefox-latest.tar.bz2 $FIREFOX_SOURCE_URL
   - tar -xjf /tmp/firefox-latest.tar.bz2
   - export PATH=$PWD/firefox:$PATH
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.20.0
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.21.0
   - export PATH="$HOME/.yarn/bin:$PATH"
 install:
   - pip install -r requirements/requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
   - wget --no-verbose -O /tmp/firefox-latest.tar.bz2 $FIREFOX_SOURCE_URL
   - tar -xjf /tmp/firefox-latest.tar.bz2
   - export PATH=$PWD/firefox:$PATH
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.21.1
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.22.0
   - export PATH="$HOME/.yarn/bin:$PATH"
 install:
   - pip install -r requirements/requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
   - wget --no-verbose -O /tmp/firefox-latest.tar.bz2 $FIREFOX_SOURCE_URL
   - tar -xjf /tmp/firefox-latest.tar.bz2
   - export PATH=$PWD/firefox:$PATH
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.22.3
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.22.4
   - export PATH="$HOME/.yarn/bin:$PATH"
 install:
   - pip install -r requirements/requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ install:
   - pip install -r requirements/requirements.txt
   - pip install -r requirements/requ-testing.txt
   - yarn
+  - ls -al libreosteoweb/static/components/moment/
+  - ls -al libreosteoweb/static/components/moment/meteor/
   - wget https://github.com/mozilla/geckodriver/releases/download/v0.21.0/geckodriver-v0.21.0-linux64.tar.gz -O /tmp/geckodriver.tar.gz
   - tar -xvf /tmp/geckodriver.tar.gz
   - export PATH=$PATH:$PWD

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
   - wget --no-verbose -O /tmp/firefox-latest.tar.bz2 $FIREFOX_SOURCE_URL
   - tar -xjf /tmp/firefox-latest.tar.bz2
   - export PATH=$PWD/firefox:$PATH
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.22.4
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.21.1
   - export PATH="$HOME/.yarn/bin:$PATH"
 install:
   - pip install -r requirements/requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
   - wget --no-verbose -O /tmp/firefox-latest.tar.bz2 $FIREFOX_SOURCE_URL
   - tar -xjf /tmp/firefox-latest.tar.bz2
   - export PATH=$PWD/firefox:$PATH
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.19.1
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.19.2
   - export PATH="$HOME/.yarn/bin:$PATH"
 install:
   - pip install -r requirements/requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
   - wget --no-verbose -O /tmp/firefox-latest.tar.bz2 $FIREFOX_SOURCE_URL
   - tar -xjf /tmp/firefox-latest.tar.bz2
   - export PATH=$PWD/firefox:$PATH
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.22.0
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.22.1
   - export PATH="$HOME/.yarn/bin:$PATH"
 install:
   - pip install -r requirements/requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 language: python
-cache:
-  npm: false
-  yarn: false
 before_install:
   - export FIREFOX_SOURCE_URL='https://download.mozilla.org/?product=firefox-latest&lang=fr&os=linux64'
   - wget --no-verbose -O /tmp/firefox-latest.tar.bz2 $FIREFOX_SOURCE_URL
   - tar -xjf /tmp/firefox-latest.tar.bz2
   - export PATH=$PWD/firefox:$PATH
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.19.1
+  - export PATH="$HOME/.yarn/bin:$PATH"
 install:
   - pip install -r requirements/requirements.txt
   - pip install -r requirements/requ-testing.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
   - wget --no-verbose -O /tmp/firefox-latest.tar.bz2 $FIREFOX_SOURCE_URL
   - tar -xjf /tmp/firefox-latest.tar.bz2
   - export PATH=$PWD/firefox:$PATH
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.22.2
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.22.3
   - export PATH="$HOME/.yarn/bin:$PATH"
 install:
   - pip install -r requirements/requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ install:
   - pip install -r requirements/requirements.txt
   - pip install -r requirements/requ-testing.txt
   - yarn
-  - ls -al libreosteoweb/static/components/moment/
-  - ls -al libreosteoweb/static/components/moment/meteor/
   - wget https://github.com/mozilla/geckodriver/releases/download/v0.21.0/geckodriver-v0.21.0-linux64.tar.gz -O /tmp/geckodriver.tar.gz
   - tar -xvf /tmp/geckodriver.tar.gz
   - export PATH=$PATH:$PWD

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: python
+cache:
+  npm: false
+  yarn: false
 before_install:
   - export FIREFOX_SOURCE_URL='https://download.mozilla.org/?product=firefox-latest&lang=fr&os=linux64'
   - wget --no-verbose -O /tmp/firefox-latest.tar.bz2 $FIREFOX_SOURCE_URL

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
   - wget --no-verbose -O /tmp/firefox-latest.tar.bz2 $FIREFOX_SOURCE_URL
   - tar -xjf /tmp/firefox-latest.tar.bz2
   - export PATH=$PWD/firefox:$PATH
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.19.2
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.20.0
   - export PATH="$HOME/.yarn/bin:$PATH"
 install:
   - pip install -r requirements/requirements.txt

--- a/package.json
+++ b/package.json
@@ -5,12 +5,7 @@
   "description": "Libreosteo",
   "repository": "https://github.com/garthylou/Libreosteo",
   "license": "GNU-GPL",
-  "devDependencies": {
-    "karma": "~0.10",
-    "protractor": "~0.20.1",
-    "http-server": "^0.6.1",
-    "karma-junit-reporter": "^0.2.2"
-  },
+  "devDependencies": {},
   "scripts": {
     "postinstall": "node -e \"try { require('fs').symlinkSync(require('path').resolve('node_modules/@components'), 'libreosteoweb/static/components', 'junction') } catch (e) { }\"",
     "prestart": "npm install",
@@ -21,13 +16,12 @@
     "update-webdriver": "webdriver-manager update",
     "preprotractor": "npm run update-webdriver",
     "protractor": "protractor test/protractor-conf.js",
-
     "update-index-async": "node -e \"require('shelljs/global'); sed('-i', /\\/\\/@@NG_LOADER_START@@[\\s\\S]*\\/\\/@@NG_LOADER_END@@/, '//@@NG_LOADER_START@@\\n' + cat('libreosteoweb/components/angular-loader/angular-loader.min.js') + '\\n//@@NG_LOADER_END@@', 'libreosteoweb/index-async.html');\""
   },
   "dependencies": {
     "@components/angular": "angular/bower-angular#1.5.11",
     "@components/angular-animate": "angular/bower-angular-animate#1.5.x",
-    "@components/angular-bind-html-compile" : "git+https://github.com/incuna/angular-bind-html-compile.git#1.1.0",
+    "@components/angular-bind-html-compile": "git+https://github.com/incuna/angular-bind-html-compile.git#1.1.0",
     "@components/angular-bootstrap": "angular-ui/bootstrap-bower#2.5.x",
     "@components/angular-cookies": "angular/bower-angular-cookies#1.5.x",
     "@components/angular-daterangepicker": "fragaria/angular-daterangepicker#^0.2.2",


### PR DESCRIPTION
This fix removes some dev dependencies from the package.json (karma, protractor and http-server) because useless in our context.
This fix try to identify the last yarn version which does not generate issue with symbolic link and the dependency momentjs